### PR TITLE
Change registerPlugin to add plugin after Extensions plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ export default {
 | `setContent` | `content, emitUpdate, parseOptions` | Replace the current content. You can pass an HTML string or a JSON document. `emitUpdate` defaults to `false`. `parseOptions` defaults to those provided in constructor. |
 | `clearContent` | `emitUpdate` | Clears the current content. `emitUpdate` defaults to `false`. |
 | `setOptions` | `options` | Overwrites the current editor properties. |
-| `registerPlugin` | `plugin` | Register a Prosemirror plugin. |
+| `registerPlugin` | `plugin`, `handlePlugins` | Register a Prosemirror plugin. You can pass a function `handlePlugins` with parameters `(plugin, oldPlugins)` to define an order in which `newPlugins` will be called. `handlePlugins` defaults to pushing `plugin` to front of `oldPlugins`. |
 | `getJSON` | – | Get the current content as JSON. |
 | `getHTML` | – | Get the current content as HTML. |
 | `focus` | – | Focus the editor. |

--- a/packages/tiptap/src/Editor.js
+++ b/packages/tiptap/src/Editor.js
@@ -487,14 +487,10 @@ export default class Editor extends Emitter {
       }), {})
   }
 
-  registerPlugin(plugin = null) {
-    if (!plugin) {
-      return
-    }
-
-    this.plugins.push(plugin);
-    this.state.plugins.splice(this.plugins.length, 0, plugin);
-    const newState = this.state.reconfigure({plugins: this.state.plugins});
+  registerPlugin(plugin = null, handlePlugins) {
+    const plugins = typeof handlePlugins === 'function'
+      ? handlePlugins(plugin, this.state.plugins) : [...plugin, this.state.plugins]
+    const newState = this.state.reconfigure({ plugins })
     this.view.updateState(newState)
   }
 

--- a/packages/tiptap/src/Editor.js
+++ b/packages/tiptap/src/Editor.js
@@ -492,9 +492,9 @@ export default class Editor extends Emitter {
       return
     }
 
-    const newState = this.state.reconfigure({
-      plugins: this.state.plugins.concat([plugin]),
-    })
+    this.plugins.push(plugin);
+    this.state.plugins.splice(this.plugins.length, 0, plugin);
+    const newState = this.state.reconfigure({plugins: this.state.plugins});
     this.view.updateState(newState)
   }
 


### PR DESCRIPTION
This commit changes `registerPlugin` by 1. adding the new plugin to `this.plugins` and 2. updating `this.plugins` within `this.state.plugins` by splicing with the new `this.plugins` length. Previously, new plugins were simply added to the end of `this.state.plugins` and were not appended to `this.plugins`. 

By placing registered plugins at this new location within `this.state.plugins`, we prioritize registered plugins over default ProseMirror plugins such as `keymap(baseKeymap)`. This will allow new plugins to have precedence over props such as `handleKeyDown`. A use case of this defining a floating Editor Menu that's navigable with arrow and enter keys.